### PR TITLE
Fix QuickExtract networkDevices url

### DIFF
--- a/HistoricalDataFetcher.QuickExtract/Program.cs
+++ b/HistoricalDataFetcher.QuickExtract/Program.cs
@@ -52,7 +52,7 @@ namespace HistoricalDataFetcher.QuickExtract
 
             //Run a quick sample list
             var qsTime = new TimeSeriesQuickstartEndPoint(new TimeSeriesSaveToCsv());
-            await qsTime.RunAsync($"{ApiRequest.UrlBase}/v1/networkDevices?page=1&pageSize=10");
+            await qsTime.RunAsync($"{ApiRequest.UrlBase}/networkDevices?page=1&pageSize=10");
 
             System.Console.WriteLine("Done!");
         }


### PR DESCRIPTION
The QuickExtract inital `/networkDevices` API call has redundant
version numbers due to the UrlBase also having a `v1`.

Removing the `v1` from the QuickExtract program fixes the
`/networkDevices` request.